### PR TITLE
Implemented header and exhibit sections

### DIFF
--- a/src/pages/Home/ExhibitSection.tsx
+++ b/src/pages/Home/ExhibitSection.tsx
@@ -1,0 +1,80 @@
+import { Box, Text, useBreakpointValue } from '@chakra-ui/react';
+
+export const ExhibitSection = () => {
+  const titleFontSize = useBreakpointValue({ base: "2xl", md: "3xl", lg: "4xl" });
+  const subtitleFontSize = useBreakpointValue({ base: "xl", md: "2xl" });
+  
+  return (
+    <section>
+      <Box 
+        display="flex" 
+        flexDirection={{ base: "column", md: "row" }}
+        justifyContent="space-between" 
+        alignItems={{ base: "center", md: "center" }} 
+        maxWidth="6xl"
+        mx="auto" 
+        my={{ base: 10, md: 20 }} 
+        px={{ base: 5, md: 10 }}
+        gap={{ base: 8, md: 0 }}
+      >
+        <Box mb={{ base: 6, md: 0 }} textAlign={{ base: "center", md: "left" }}>
+          <Text 
+            fontSize={titleFontSize} 
+            fontStyle="italic" 
+            fontFamily="mono"
+          >
+            Exhibit A
+          </Text>
+          <Text 
+            fontSize={subtitleFontSize} 
+            fontFamily="mono"
+          >
+            RP 2025 Site
+          </Text>
+        </Box>
+        
+        <Box width={{ base: "100%", md: "auto" }}>
+          <Box 
+            bgColor="gray.300" 
+            px={{ base: 20, md: 40 }} 
+            py={{ base: 16, md: 20 }} 
+            borderRadius={20}
+            mx="auto"
+            maxWidth={{ base: "400px", md: "none" }}
+          >
+            <Text 
+              fontFamily="mono" 
+              fontSize={subtitleFontSize}
+              textAlign="center"
+            >
+              RP 2025
+            </Text>
+          </Box>
+
+          <Box 
+            bgColor="gray.300" 
+            px={{ base: 20, md: 40 }} 
+            h={{base: 5, md: 8}} 
+            borderRadius={5} 
+            mt={5}
+            mx="auto"
+            maxWidth={{ base: "400px", md: "none" }}
+          />
+          
+          <Box 
+            px={{ base: 5, md: 10 }} 
+            display="flex" 
+            justifyContent="space-between"
+            maxWidth={{ base: "400px", md: "none" }}
+            mx="auto"
+          >
+            <Box bgColor="gray.300" 
+            w={{base: 5, md: 8}} h={6} />
+            <Box bgColor="gray.300" 
+            w={{base: 5, md: 8}}  h={6} />
+          </Box>
+        </Box>
+      </Box>
+    </section>
+  );
+}

--- a/src/pages/Home/Header.tsx
+++ b/src/pages/Home/Header.tsx
@@ -1,4 +1,58 @@
-import { Box, Heading } from '@chakra-ui/react'
-export const Header = () => (
-  <Box py={10}><Heading>Section 1</Heading></Box>
-)
+import { Box, Flex, Heading, Text, useBreakpointValue } from '@chakra-ui/react';
+
+export const Header = () => {
+  // Use responsive font sizes based on screen size
+  const headingSize = useBreakpointValue({ base: "lg", sm: "xl", md: "2xl", lg: "3xl" });
+  
+  return (
+    <section>
+      <Box py={{ base: 5, md: 10 }} w="100%" justifyContent="center">
+        <Box 
+          width={{ base: "90%", md: "80%", lg: 600 }} 
+          h={{ base: 200, md: 300 }} 
+          bgColor="gray.300" 
+          mx="auto" 
+          borderRadius={20} 
+          mt={{ base: 15, md: 30 }}
+        >
+          <Text>Carousel?</Text>
+        </Box>
+      </Box>
+
+      <Box py={{ base: 3, md: 5 }} w="100%" justifyContent="center">
+        <Flex 
+          direction="row"
+          alignItems="center" 
+          justifyContent="center" 
+          gap={{ base: 3, md: 30 }}
+          px={{ base: 4, md: 0 }}
+          flexWrap={{ base: "nowrap", md: "nowrap" }}
+        >
+          <Heading 
+            size={headingSize} 
+            fontFamily="mono" 
+            color="gray.900" 
+            textAlign="center"
+          >
+            REFLECTIONS
+          </Heading>
+          
+          <Box 
+            w={1}
+            h={{ base: 50, md: 100 }}
+            bgColor="gray.500"
+          />
+          
+          <Heading 
+            size={headingSize} 
+            fontFamily="mono" 
+            color="gray.900" 
+            textAlign="center"
+          >
+            PROJECTIONS
+          </Heading>
+        </Flex>
+      </Box>
+    </section>
+  );
+};

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,10 +1,12 @@
 // src/routes/Home.tsx
+import { ExhibitSection } from '../pages/Home/ExhibitSection'
 import { Header } from '../pages/Home/Header'
 
 export const Home = () => {
   return (
     <>
       <Header />
+      <ExhibitSection />
     </>
   )
 }


### PR DESCRIPTION
- Implemented the header and exhibit sections:

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/ca8a5907-38b8-4fd5-95d9-5ea5ffea11d4" />

<img width="502" alt="image" src="https://github.com/user-attachments/assets/b595f90f-5a3f-4efd-99c7-ab02ff4a3b2c" />

TODO:
- Keep or remove the carousel, based on design team's decision
- Possibly add colors and/or imagery to the exhibit section, also based on design team's decision